### PR TITLE
Issues #8 & #10 

### DIFF
--- a/CodeFirst.Tests/ContentTypeBuilderTests.cs
+++ b/CodeFirst.Tests/ContentTypeBuilderTests.cs
@@ -51,7 +51,7 @@ namespace CodeFirst.Tests
                     Assert.Equal("something", f.SystemProperties.Id);
                     Assert.Equal("field1", f.DisplayField);
                     Assert.Equal("Some description", f.Description);
-                    Assert.Equal(5, f.Fields.Count);
+                    Assert.Equal(6, f.Fields.Count);
                 }
                 );
         }
@@ -120,14 +120,15 @@ namespace CodeFirst.Tests
             var first = contentTypes.First();
             //Assert
             Assert.Equal(1, contentTypes.Count());
-            Assert.Equal(5, first.Fields.Count);
+            Assert.Equal(6, first.Fields.Count);
             Assert.Equal(1, first.Fields[2].Validations.Count);
             Assert.Equal(1, first.Fields[2].Items.Validations.Count);
             Assert.IsType<SizeValidator>(first.Fields[2].Validations[0]);
             Assert.IsType<LinkContentTypeValidator>(first.Fields[2].Items.Validations[0]);
             Assert.Equal("Array", first.Fields[2].Type);
             Assert.Equal("Entry", first.Fields[2].Items.LinkType);
-            Assert.Equal("Person", first.Fields[2].Items.Type);
+            Assert.Equal("Link", first.Fields[2].Items.Type);
+            Assert.Equal("Person", string.Join(",", (first.Fields[2].Items.Validations[0] as LinkContentTypeValidator).ContentTypeIds));
             Assert.Equal("Text", first.Fields[1].Type);
             Assert.Equal(4, first.Fields[1].Validations.Count);
             Assert.Equal(1, first.Fields[4].Validations.Count);
@@ -141,6 +142,13 @@ namespace CodeFirst.Tests
             Assert.Null((first.Fields[3].Validations[2] as ImageSizeValidator).MaxHeight);
             Assert.Equal(200, (first.Fields[3].Validations[2] as ImageSizeValidator).MinWidth);
             Assert.Equal(200, (first.Fields[3].Validations[2] as ImageSizeValidator).MinWidth);
+            Assert.Equal(0, first.Fields[5].Validations.Count);
+            Assert.Equal(1, first.Fields[5].Items.Validations.Count);
+            Assert.IsType<LinkContentTypeValidator>(first.Fields[5].Items.Validations[0]);
+            Assert.Equal("Array", first.Fields[5].Type);
+            Assert.Equal("Entry", first.Fields[5].Items.LinkType);
+            Assert.Equal("Link", first.Fields[5].Items.Type);
+            Assert.Equal("Person", string.Join(",", (first.Fields[5].Items.Validations[0] as LinkContentTypeValidator).ContentTypeIds));
 
             Assert.Collection(first.Fields[1].Validations,
                 (f) => { Assert.IsType<UniqueValidator>(f); },

--- a/CodeFirst.Tests/TestClasses/ClassWithAttributes.cs
+++ b/CodeFirst.Tests/TestClasses/ClassWithAttributes.cs
@@ -20,7 +20,7 @@ namespace CodeFirst.Tests.TestClasses
         [Regex(Expression = "ss", Flags = "gi")]
         public string Field2 { get; set; }
 
-        [ContentField(Id="collection", ItemsLinkType="Entry", ItemsType = "Person")]
+        [ContentField(Id="collection", ItemsLinkType="Entry", ItemsType = "Link")]
         [Size(HelpText = "Too many or too few!", Max = 5, Min = 2)]
         [LinkContentType("Person")]
         public List<Person> Field3 { get; set; }
@@ -35,6 +35,10 @@ namespace CodeFirst.Tests.TestClasses
 
         [DateRange(Min = "2017-01-01")]
         public DateTime Field4 { get; set; }
+
+        [ContentField(Id = "collection")]
+        [LinkContentType("Person")]
+        public List<Person> Field5 { get; set; }
     }
 
     [ContentType]

--- a/CodeFirst/ContentTypeBuilder.cs
+++ b/CodeFirst/ContentTypeBuilder.cs
@@ -89,7 +89,7 @@ namespace Contentful.CodeFirst
                         Disabled = fieldAttribute.Disabled,
                         Omitted = fieldAttribute.Omitted,
                         Required = fieldAttribute.Required,
-                        LinkType = fieldAttribute.LinkType,
+                        LinkType = fieldAttribute.LinkType ?? FieldTypeConverter.ConvertLinkType(prop.PropertyType),
                         Validations = new List<IFieldValidator>()
                     };
                     var validationAttributes = prop.GetCustomAttributes<ContentfulValidationAttribute>();
@@ -99,8 +99,8 @@ namespace Contentful.CodeFirst
                     {
                         field.Items = new Schema()
                         {
-                            LinkType = fieldAttribute.ItemsLinkType,
-                            Type = fieldAttribute.ItemsType,
+                            LinkType = fieldAttribute.ItemsLinkType ?? FieldTypeConverter.ConvertItemLinkType(prop.PropertyType),
+                            Type = fieldAttribute.ItemsType ?? FieldTypeConverter.ConvertItemType(prop.PropertyType),
                             Validations = new List<IFieldValidator>()
                         };
                     }

--- a/CodeFirst/FieldTypeConverter.cs
+++ b/CodeFirst/FieldTypeConverter.cs
@@ -3,6 +3,7 @@ using Contentful.Core.Models.Management;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 
@@ -20,37 +21,37 @@ namespace Contentful.CodeFirst
         /// <returns>The field type.</returns>
         public static string Convert(Type type)
         {
-            if(type == typeof(int) || type == typeof(int?))
+            if (type == typeof(int) || type == typeof(int?))
             {
                 return SystemFieldTypes.Integer;
             }
 
-            if(type == typeof(string))
+            if (type == typeof(string))
             {
                 return SystemFieldTypes.Text;
             }
 
-            if(type == typeof(float) || type == typeof(decimal) || type == typeof(double) || type == typeof(float?) || type == typeof(decimal?) || type == typeof(double?))
+            if (type == typeof(float) || type == typeof(decimal) || type == typeof(double) || type == typeof(float?) || type == typeof(decimal?) || type == typeof(double?))
             {
                 return SystemFieldTypes.Number;
             }
 
-            if(type == typeof(DateTime) || type == typeof(DateTime?))
+            if (type == typeof(DateTime) || type == typeof(DateTime?))
             {
                 return SystemFieldTypes.Date;
             }
 
-            if(type == typeof(bool) || type == typeof(bool?))
+            if (type == typeof(bool) || type == typeof(bool?))
             {
                 return SystemFieldTypes.Boolean;
             }
 
-            if(type == typeof(Asset) || type == typeof(ManagementAsset) || (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Entry<>)))
+            if (IsAsset(type) || IsEntry(type))
             {
                 return SystemFieldTypes.Link;
             }
 
-            if(typeof(ICollection).IsAssignableFrom(type))
+            if (typeof(ICollection).IsAssignableFrom(type))
             {
                 return SystemFieldTypes.Array;
             }
@@ -61,6 +62,72 @@ namespace Contentful.CodeFirst
             }
 
             return SystemFieldTypes.Object;
+        }
+
+        public static string ConvertLinkType(Type type)
+        {
+            if (IsAsset(type))
+            {
+                // TODO: use SystemLinkTypes.Asset when available
+                return "Asset";
+            }
+            else if (IsEntry(type))
+            {
+                // TODO: use SystemLinkTypes.Entry when available
+                return "Entry";
+            }
+            return null;
+        }
+
+        public static string ConvertItemType(Type type)
+        {
+            Type itemType = GetItemType(type);
+            if (itemType != null)
+            {
+                string convertedItemType = Convert(itemType);
+
+                // currently only a list of strings (short strings) or links are supported 
+                if (convertedItemType != SystemFieldTypes.Link)
+                    return SystemFieldTypes.Symbol;
+                else
+                    return convertedItemType;
+            }
+            return null;
+        }
+
+        public static string ConvertItemLinkType(Type type)
+        {
+            Type itemType = GetItemType(type);
+            if (itemType != null)
+            {
+                return ConvertLinkType(itemType);
+            }
+            return null;
+        }
+
+        public static bool IsAsset(Type type)
+        {
+            return type == typeof(Asset) || type == typeof(ManagementAsset);
+        }
+
+        public static bool IsEntry(Type type)
+        {
+            return (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Entry<>)) || type.GetTypeInfo().IsDefined(typeof(ContentTypeAttribute));
+        }
+
+        public static Type GetItemType(Type type)
+        {
+            if (typeof(ICollection).IsAssignableFrom(type))
+            {
+                Type itemType = null;
+                if (type.IsConstructedGenericType)
+                    itemType = type.GetGenericArguments().First();
+                if (type.IsArray)
+                    itemType = type.GetElementType();
+
+                return itemType;
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
FieldTypeConverter may not be the best place for converting link type, item type and item link type. I didn't know if you'd want a separate converter for each of those (e.g. FieldLinkTypeConverter, FieldItemTypeConverter, and FieldItemLinkTypeConverter). But I added some logic to handle those automatically if the user didn't explicitly set them in the attribute. 

I added some helper methods to the FieldTypeConverter class so I didn't have duplicate code. Typically I would've made it protected or private but since the class is static, I couldn't. Not sure if you want that in a separate utility class or if its fine for now.

I also added a check when determining if the Type is an Entry to account for the case when a developer doesn't explicitly define it as Entry<Person> and instead just <Person> by checking for a ContentTypeAttribute. Since this check happens before the default `return SystemFieldTypes.Object` it should still handle regular POCO classes correctly.

Finally, I added a bug fix/test fix for the Item type. Contentful is expecting either Link or Symbol there, not the id of the content type so I changed that in the tests and accounted for it in the conversion logic.